### PR TITLE
Add kill-based title progression

### DIFF
--- a/ELST/data/lib/core/player.lua
+++ b/ELST/data/lib/core/player.lua
@@ -527,12 +527,23 @@ function Player.addBestiaryKills(self, raceId)
 end
 
 function Player.sendBestiaryMilestoneReached(self, raceId)
-	local msg = NetworkMessage()
-	msg:addByte(0xD9)
-	msg:addU16(raceId)
-	msg:sendToPlayer(self)
-	msg:delete()
-	return true
+        local msg = NetworkMessage()
+        msg:addByte(0xD9)
+        msg:addU16(raceId)
+        msg:sendToPlayer(self)
+        msg:delete()
+        return true
+end
+
+function Player.checkKillTitle(self, raceId, monsterName)
+        if self:getBestiaryKills(raceId) >= 100 then
+                local storage = PlayerStorageKeys.killTitlesBase + raceId
+                if self:getStorageValue(storage) ~= 1 then
+                        self:setStorageValue(storage, 1)
+                        self:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("You earned the title \"Slayer of 100 %s\".", monsterName .. 's'))
+                end
+        end
+        return true
 end
 
 local function getStaminaBonus(staminaMinutes)

--- a/ELST/data/lib/core/storages.lua
+++ b/ELST/data/lib/core/storages.lua
@@ -41,6 +41,9 @@ PlayerStorageKeys = {
 	achievementsCounter = 20000,
 	achievementsBase = 300000,
 
-	-- Bestiary:
-	bestiaryKillsBase = 400000,
+        -- Bestiary:
+        bestiaryKillsBase = 400000,
+
+        -- Kill Titles:
+        killTitlesBase = 500000,
 }

--- a/ELST/data/scripts/creaturescripts/player/bestiary_kills.lua
+++ b/ELST/data/scripts/creaturescripts/player/bestiary_kills.lua
@@ -34,10 +34,11 @@ function creatureEvent.onKill(player, target)
 		return true
 	end
 
-	for _, killer in pairs(getKillersForBestiary(monster)) do
-		killer:addBestiaryKills(raceId)
-	end
-	return true
+       for _, killer in pairs(getKillersForBestiary(monster)) do
+               killer:addBestiaryKills(raceId)
+               killer:checkKillTitle(raceId, monster:getName())
+       end
+       return true
 end
 
 creatureEvent:register()


### PR DESCRIPTION
## Summary
- add kill title storage key
- add Player.checkKillTitle helper to unlock title when killing a creature 100 times
- trigger kill title check in the Bestiary kill event

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: could not find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4e69bb48332a796c3c02492c23f