### PR TITLE
Add serial items for trading

### DIFF
--- a/ELST/data/talkactions/scripts/create_item_serial.lua
+++ b/ELST/data/talkactions/scripts/create_item_serial.lua
@@ -1,0 +1,28 @@
+function onSay(player, words, param)
+    if not player:getGroup():getAccess() then
+        return true
+    end
+
+    local split = param:split(",")
+    if #split < 2 then
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "Usage: " .. words .. " itemId,serial")
+        return false
+    end
+
+    local itemId = tonumber(split[1]) or 0
+    local serial = string.trim(split[2])
+    if itemId == 0 or serial == "" then
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "Invalid parameters.")
+        return false
+    end
+
+    local item = Game.createItem(itemId, 1)
+    if not item then
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "Invalid item id.")
+        return false
+    end
+
+    item:setCustomAttribute("serial", serial)
+    player:addItemEx(item)
+    return false
+end

--- a/ELST/data/talkactions/talkactions.xml
+++ b/ELST/data/talkactions/talkactions.xml
@@ -17,7 +17,8 @@
 	<talkaction words="/closeserver" separator=" " script="close_server.lua" />
 	<talkaction words="/B" separator=" " script="broadcast.lua" />
 	<talkaction words="/m" separator=" " script="place_monster.lua" />
-	<talkaction words="/i" separator=" " script="create_item.lua" />
+        <talkaction words="/i" separator=" " script="create_item.lua" />
+        <talkaction words="/serialitem" separator=" " script="create_item_serial.lua" />
 	<talkaction words="/s" separator=" " script="place_npc.lua" />
 	<talkaction words="/addtutor" separator=" " script="add_tutor.lua" />
 	<talkaction words="/removetutor" separator=" " script="remove_tutor.lua" />

--- a/ELST/src/item.cpp
+++ b/ELST/src/item.cpp
@@ -1251,21 +1251,26 @@ bool Item::hasMarketAttributes() const
 	}
 
 	// discard items with other modified attributes
-	for (const auto& attr : attributes->getList()) {
-		if (attr.type == ITEM_ATTRIBUTE_CHARGES) {
-			uint16_t charges = static_cast<uint16_t>(attr.value.integer);
-			if (charges != items[id].charges) {
-				return false;
-			}
-		} else if (attr.type == ITEM_ATTRIBUTE_DURATION) {
-			uint32_t duration = static_cast<uint32_t>(attr.value.integer);
-			if (duration <= getDefaultDurationMin()) {
-				return false;
-			}
-		} else {
-			return false;
-		}
-	}
+        for (const auto& attr : attributes->getList()) {
+                if (attr.type == ITEM_ATTRIBUTE_CHARGES) {
+                        uint16_t charges = static_cast<uint16_t>(attr.value.integer);
+                        if (charges != items[id].charges) {
+                                return false;
+                        }
+                } else if (attr.type == ITEM_ATTRIBUTE_DURATION) {
+                        uint32_t duration = static_cast<uint32_t>(attr.value.integer);
+                        if (duration <= getDefaultDurationMin()) {
+                                return false;
+                        }
+                } else if (attr.type == ITEM_ATTRIBUTE_CUSTOM) {
+                        const ItemAttributes::CustomAttributeMap* customMap = attr.value.custom;
+                        if (!customMap || customMap->size() != 1 || customMap->find("serial") == customMap->end()) {
+                                return false;
+                        }
+                } else {
+                        return false;
+                }
+        }
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- allow marketable items to carry a `serial` custom attribute
- add `/serialitem` command to create an item with a serial

## Testing
- `cmake ..` *(fails: could not find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_6840e71889108332a2a9ad95630b1e61