### PR TITLE
Add weapon evolution mechanic

### DIFF
--- a/ELST/docs/weapon_evolution.md
+++ b/ELST/docs/weapon_evolution.md
@@ -1,0 +1,6 @@
+Weapon Evolution
+================
+
+Weapons now track how many times they have been used in combat.
+After 100 successful uses, a weapon gains +3 attack permanently.
+A message will notify you when this upgrade occurs.


### PR DESCRIPTION
## Summary
- increment weapon usecount and evolve weapon after 100 uses
- document new weapon evolution feature

## Testing
- `cmake -S ELST -B build` *(fails: Could NOT find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_684e2aac4b448332be3a182bfd806d15