### PR TITLE
Add monster interaction support

### DIFF
--- a/ELST/docs/cyber_dragon.md
+++ b/ELST/docs/cyber_dragon.md
@@ -12,3 +12,13 @@ It demonstrates an advanced monster configuration with detailed comments so you 
 * **Defenses**: Strong armor, healing ability, partial immunities.
 
 Edit the XML file to adjust these values. Each major block is commented to explain its purpose.
+
+## Interactions
+
+Monsters support an optional `<interactions>` block. For instance, to allow a monster to open doors you can add:
+
+```xml
+<interactions>
+    <interaction type="openDoor"/>
+</interactions>
+```

--- a/ELST/src/CMakeLists.txt
+++ b/ELST/src/CMakeLists.txt
@@ -40,8 +40,9 @@ set(tfs_SRC
 	${CMAKE_CURRENT_LIST_DIR}/map.cpp
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.cpp
 	${CMAKE_CURRENT_LIST_DIR}/monster.cpp
-	${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
-	${CMAKE_CURRENT_LIST_DIR}/mounts.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/monsters.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/monsteraicontroller.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/mounts.cpp
 	${CMAKE_CURRENT_LIST_DIR}/movement.cpp
 	${CMAKE_CURRENT_LIST_DIR}/networkmessage.cpp
 	${CMAKE_CURRENT_LIST_DIR}/npc.cpp
@@ -127,8 +128,9 @@ set(tfs_HDR
 	${CMAKE_CURRENT_LIST_DIR}/map.h
 	${CMAKE_CURRENT_LIST_DIR}/matrixarea.h
 	${CMAKE_CURRENT_LIST_DIR}/monster.h
-	${CMAKE_CURRENT_LIST_DIR}/monsters.h
-	${CMAKE_CURRENT_LIST_DIR}/mounts.h
+        ${CMAKE_CURRENT_LIST_DIR}/monsters.h
+        ${CMAKE_CURRENT_LIST_DIR}/monsteraicontroller.h
+        ${CMAKE_CURRENT_LIST_DIR}/mounts.h
 	${CMAKE_CURRENT_LIST_DIR}/movement.h
 	${CMAKE_CURRENT_LIST_DIR}/networkmessage.h
 	${CMAKE_CURRENT_LIST_DIR}/npc.h

--- a/ELST/src/monster.cpp
+++ b/ELST/src/monster.cpp
@@ -11,6 +11,7 @@
 #include "game.h"
 #include "spectators.h"
 #include "spells.h"
+#include "monsteraicontroller.h"
 
 extern Game g_game;
 extern Monsters g_monsters;
@@ -785,8 +786,9 @@ void Monster::onThink(uint32_t interval)
 	} else {
 		updateIdleStatus();
 
-		if (!isIdle) {
-			addEventWalk();
+                if (!isIdle) {
+                        addEventWalk();
+                       MonsterAIController::processInteractions(this);
 
 			if (isSummon()) {
 				if (!attackedCreature) {

--- a/ELST/src/monster.h
+++ b/ELST/src/monster.h
@@ -78,8 +78,10 @@ public:
 	bool isHostile() const { return mType->info.isHostile; }
 	bool canSee(const Position& pos) const override;
 	bool canSeeInvisibility() const override { return isImmune(CONDITION_INVISIBLE); }
-	uint32_t getManaCost() const { return mType->info.manaCost; }
-	void setSpawn(Spawn* spawn) { this->spawn = spawn; }
+        uint32_t getManaCost() const { return mType->info.manaCost; }
+       MonsterType* getMonsterType() { return mType; }
+       const MonsterType* getMonsterType() const { return mType; }
+       void setSpawn(Spawn* spawn) { this->spawn = spawn; }
 	bool canWalkOnFieldType(CombatType_t combatType) const;
 
 	void onAttackedCreatureDisappear(bool isLogout) override;

--- a/ELST/src/monsteraicontroller.cpp
+++ b/ELST/src/monsteraicontroller.cpp
@@ -1,0 +1,33 @@
+#include "otpch.h"
+
+#include "monsteraicontroller.h"
+#include "monster.h"
+#include "game.h"
+#include "tile.h"
+#include "item.h"
+
+extern Game g_game;
+
+void MonsterAIController::processInteractions(Monster* monster)
+{
+        const auto& interactions = monster->getMonsterType()->info.interactions;
+        for (MonsterInteractionType type : interactions) {
+                switch (type) {
+                        case MonsterInteractionType::OPEN_DOOR: {
+                                // open door in front of the monster if present
+                                Position pos = monster->getPosition();
+                                Position ahead = pos.getNextPosition(monster->getDirection());
+                                Tile* tile = g_game.map.getTile(ahead);
+                                if (!tile) {
+                                        continue;
+                                }
+                                Item* doorItem = tile->getItemByType(ITEM_TYPE_DOOR);
+                                if (!doorItem) {
+                                        continue;
+                                }
+                                g_game.transformItem(doorItem, doorItem->getID() + 1);
+                                break;
+                        }
+                }
+        }
+}

--- a/ELST/src/monsteraicontroller.h
+++ b/ELST/src/monsteraicontroller.h
@@ -1,0 +1,14 @@
+#ifndef FS_MONSTER_AICONTROLLER_H
+#define FS_MONSTER_AICONTROLLER_H
+
+#include "monsters.h"
+
+class Monster;
+
+class MonsterAIController
+{
+public:
+        static void processInteractions(Monster* monster);
+};
+
+#endif // FS_MONSTER_AICONTROLLER_H

--- a/ELST/src/monsters.cpp
+++ b/ELST/src/monsters.cpp
@@ -1459,23 +1459,37 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 		}
 	}
 
-	if ((node = monsterNode.child("script"))) {
-		for (auto eventNode : node.children()) {
-			if ((attr = eventNode.attribute("name"))) {
-				mType->info.scripts.emplace_back(attr.as_string());
-			} else {
-				std::cout << "[Warning - Monsters::loadMonster] Missing name for script event. " << file << std::endl;
-			}
-		}
-	}
+        if ((node = monsterNode.child("script"))) {
+                for (auto eventNode : node.children()) {
+                        if ((attr = eventNode.attribute("name"))) {
+                                mType->info.scripts.emplace_back(attr.as_string());
+                        } else {
+                                std::cout << "[Warning - Monsters::loadMonster] Missing name for script event. " << file << std::endl;
+                        }
+                }
+        }
+
+       if ((node = monsterNode.child("interactions"))) {
+               for (auto intNode : node.children()) {
+                       if ((attr = intNode.attribute("type"))) {
+                               std::string type = boost::algorithm::to_lower_copy<std::string>(attr.as_string());
+                               if (type == "opendoor") {
+                                       mType->info.interactions.push_back(MonsterInteractionType::OPEN_DOOR);
+                               } else {
+                                       std::cout << "[Warning - Monsters::loadMonster] Unknown interaction type: " << attr.as_string() << ' ' << file << std::endl;
+                               }
+                       }
+               }
+       }
 
 	mType->info.summons.shrink_to_fit();
 	mType->info.lootItems.shrink_to_fit();
 	mType->info.attackSpells.shrink_to_fit();
 	mType->info.defenseSpells.shrink_to_fit();
-	mType->info.voiceVector.shrink_to_fit();
-	mType->info.scripts.shrink_to_fit();
-	return mType;
+       mType->info.voiceVector.shrink_to_fit();
+       mType->info.scripts.shrink_to_fit();
+       mType->info.interactions.shrink_to_fit();
+       return mType;
 }
 
 bool MonsterType::loadCallback(LuaScriptInterface* scriptInterface)

--- a/ELST/src/monsters.h
+++ b/ELST/src/monsters.h
@@ -93,8 +93,13 @@ struct spellBlock_t
 
 struct voiceBlock_t
 {
-	std::string text;
-	bool yellText;
+        std::string text;
+        bool yellText;
+};
+
+enum class MonsterInteractionType
+{
+        OPEN_DOOR,
 };
 
 struct BestiaryInfo
@@ -123,8 +128,9 @@ class MonsterType
 		std::vector<LootBlock> lootItems;
 		std::vector<std::string> scripts;
 		std::vector<spellBlock_t> attackSpells;
-		std::vector<spellBlock_t> defenseSpells;
-		std::vector<summonBlock_t> summons;
+                std::vector<spellBlock_t> defenseSpells;
+                std::vector<summonBlock_t> summons;
+                std::vector<MonsterInteractionType> interactions;
 
 		Skulls_t skull = SKULL_NONE;
 		Outfit_t outfit = {};


### PR DESCRIPTION
## Summary
- enable optional `<interactions>` block for monster XML definitions
- parse `<interaction type="openDoor"/>` into monster types
- add `MonsterAIController` to perform interactions like opening doors
- call AI controller during monster thinking
- document usage with an example in `cyber_dragon.md`

## Testing
- `cmake --preset default` *(fails: Could not find a package configuration file provided by "fmt")*
- `ctest --preset default` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef06d70e083328ecb180af3a83094