### PR TITLE
Add /aidebug toggle for AI logs

### DIFF
--- a/ELST/data/talkactions/scripts/aidebug.lua
+++ b/ELST/data/talkactions/scripts/aidebug.lua
@@ -1,0 +1,21 @@
+function onSay(player, words, param)
+    if not player:getGroup():getAccess() then
+        return true
+    end
+
+    if player:getAccountType() < ACCOUNT_TYPE_GOD then
+        return false
+    end
+
+    local setting = param:lower()
+    if setting == "on" then
+        Game.setAIDebug(true)
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "AI debugging enabled.")
+    elseif setting == "off" then
+        Game.setAIDebug(false)
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "AI debugging disabled.")
+    else
+        player:sendTextMessage(MESSAGE_INFO_DESCR, "Usage: /aidebug on|off")
+    end
+    return false
+end

--- a/ELST/data/talkactions/talkactions.xml
+++ b/ELST/data/talkactions/talkactions.xml
@@ -29,8 +29,9 @@
 	<talkaction words="/mccheck" script="mc_check.lua" />
 	<talkaction words="/ghost" script="ghost.lua" />
 	<talkaction words="/clean" script="clean.lua" />
-	<talkaction words="/hide" script="hide.lua" />
-	<talkaction words="/reload" separator=" " script="reload.lua" />
+        <talkaction words="/hide" script="hide.lua" />
+        <talkaction words="/reload" separator=" " script="reload.lua" />
+        <talkaction words="/aidebug" separator=" " script="aidebug.lua" />
 
 	<!-- player talkactions -->
 	<talkaction words="!buypremium" script="buy_premium.lua" />

--- a/ELST/docs/monster_ai_system.md
+++ b/ELST/docs/monster_ai_system.md
@@ -1,0 +1,11 @@
+# Monster AI System
+
+This document describes the basics of the monster behaviour system.
+
+## Debugging
+
+Use `/aidebug on` to enable detailed logging of monster AI decisions.
+Use `/aidebug off` to disable the logs.
+
+When enabled, the server prints information about each monster on every think cycle.
+Lua scripts can check `Game.isAIDebugEnabled()` and print additional data such as active behaviour tree nodes if desired.

--- a/ELST/src/game.cpp
+++ b/ELST/src/game.cpp
@@ -75,6 +75,10 @@ GameState_t Game::getGameState() const { return gameState; }
 
 void Game::setWorldType(WorldType_t type) { worldType = type; }
 
+void Game::setAIDebug(bool value) { aiDebug = value; }
+
+bool Game::isAIDebug() const { return aiDebug; }
+
 void Game::setGameState(GameState_t newState)
 {
 	if (gameState == GAME_STATE_SHUTDOWN) {
@@ -5126,12 +5130,13 @@ void Game::playerDebugAssert(uint32_t playerId, const std::string& assertLine, c
 		return;
 	}
 
-       Database& db = Database::getInstance();
-       const std::string query = fmt::format(
-               "INSERT INTO `client_assertions` (`player_id`, `created_at`, `assert_line`, `assert_date`, `description`, `comment`) VALUES ({:d}, {:d}, {:s}, {:s}, {:s}, {:s})",
-               playerId, time(nullptr), db.escapeString(assertLine), db.escapeString(date), db.escapeString(description), db.escapeString(comment));
+	Database& db = Database::getInstance();
+	const std::string query = fmt::format(
+	    "INSERT INTO `client_assertions` (`player_id`, `created_at`, `assert_line`, `assert_date`, `description`, `comment`) VALUES ({:d}, {:d}, {:s}, {:s}, {:s}, {:s})",
+	    playerId, time(nullptr), db.escapeString(assertLine), db.escapeString(date), db.escapeString(description),
+	    db.escapeString(comment));
 
-       g_databaseTasks.addTask(query);
+	g_databaseTasks.addTask(query);
 }
 
 void Game::playerLeaveMarket(uint32_t playerId)
@@ -5728,12 +5733,12 @@ Guild_ptr Game::getGuild(uint32_t id) const
 	return it->second;
 }
 
-void Game::addGuild(Guild_ptr guild) 
+void Game::addGuild(Guild_ptr guild)
 {
-  if (!guild) {
-     return;
-   }
-   
+	if (!guild) {
+		return;
+	}
+
 	guilds[guild->getId()] = guild;
 }
 

--- a/ELST/src/game.h
+++ b/ELST/src/game.h
@@ -97,6 +97,8 @@ public:
 
 	void setWorldType(WorldType_t type);
 	WorldType_t getWorldType() const { return worldType; }
+	void setAIDebug(bool value);
+	bool isAIDebug() const { return aiDebug; }
 
 	Cylinder* internalGetCylinder(Player* player, const Position& pos) const;
 	Thing* internalGetThing(Player* player, const Position& pos, int32_t index, uint32_t spriteId,
@@ -533,6 +535,7 @@ private:
 
 	GameState_t gameState = GAME_STATE_NORMAL;
 	WorldType_t worldType = WORLD_TYPE_PVP;
+	bool aiDebug = false;
 
 	ServiceManager* serviceManager = nullptr;
 

--- a/ELST/src/luascript.cpp
+++ b/ELST/src/luascript.cpp
@@ -2400,6 +2400,8 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod(L, "Game", "getWorldType", LuaScriptInterface::luaGameGetWorldType);
 	registerMethod(L, "Game", "setWorldType", LuaScriptInterface::luaGameSetWorldType);
+	registerMethod(L, "Game", "isAIDebugEnabled", LuaScriptInterface::luaGameIsAIDebugEnabled);
+	registerMethod(L, "Game", "setAIDebug", LuaScriptInterface::luaGameSetAIDebug);
 
 	registerMethod(L, "Game", "getItemAttributeByName", LuaScriptInterface::luaGameGetItemAttributeByName);
 	registerMethod(L, "Game", "getReturnMessage", LuaScriptInterface::luaGameGetReturnMessage);
@@ -4610,15 +4612,15 @@ int LuaScriptInterface::luaGameLoadMap(lua_State* L)
 {
 	// Game.loadMap(path)
 	const std::string& path = tfs::lua::getString(L, 1);
-       g_dispatcher.addTask([path]() {
-               try {
-                       g_game.loadMap(path, true);
-               } catch (const std::runtime_error& e) {
-                       std::cout << "[Error - LuaScriptInterface::luaGameLoadMap] Failed to load map: " << e.what() << '\n';
-               } catch (const std::exception& e) {
-                       std::cout << "[Error - LuaScriptInterface::luaGameLoadMap] Unexpected error: " << e.what() << '\n';
-               }
-       });
+	g_dispatcher.addTask([path]() {
+		try {
+			g_game.loadMap(path, true);
+		} catch (const std::runtime_error& e) {
+			std::cout << "[Error - LuaScriptInterface::luaGameLoadMap] Failed to load map: " << e.what() << '\n';
+		} catch (const std::exception& e) {
+			std::cout << "[Error - LuaScriptInterface::luaGameLoadMap] Unexpected error: " << e.what() << '\n';
+		}
+	});
 	return 0;
 }
 
@@ -4869,6 +4871,22 @@ int LuaScriptInterface::luaGameSetWorldType(lua_State* L)
 	// Game.setWorldType(type)
 	WorldType_t type = tfs::lua::getNumber<WorldType_t>(L, 1);
 	g_game.setWorldType(type);
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaGameIsAIDebugEnabled(lua_State* L)
+{
+	// Game.isAIDebugEnabled()
+	tfs::lua::pushBoolean(L, g_game.isAIDebug());
+	return 1;
+}
+
+int LuaScriptInterface::luaGameSetAIDebug(lua_State* L)
+{
+	// Game.setAIDebug(enabled)
+	bool enabled = tfs::lua::getBoolean(L, 1);
+	g_game.setAIDebug(enabled);
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }

--- a/ELST/src/luascript.h
+++ b/ELST/src/luascript.h
@@ -292,6 +292,8 @@ private:
 
 	static int luaGameGetWorldType(lua_State* L);
 	static int luaGameSetWorldType(lua_State* L);
+	static int luaGameIsAIDebugEnabled(lua_State* L);
+	static int luaGameSetAIDebug(lua_State* L);
 
 	static int luaGameGetItemAttributeByName(lua_State* L);
 	static int luaGameGetReturnMessage(lua_State* L);

--- a/ELST/src/monster.cpp
+++ b/ELST/src/monster.cpp
@@ -742,6 +742,17 @@ void Monster::onThink(uint32_t interval)
 {
 	Creature::onThink(interval);
 
+	if (g_game.isAIDebug()) {
+		std::cout << "[AI] " << getName() << " pos(" << position.x << ',' << position.y << ','
+		          << static_cast<int>(position.z) << ")";
+		if (attackedCreature) {
+			std::cout << " target: " << attackedCreature->getName();
+		} else {
+			std::cout << " target: none";
+		}
+		std::cout << std::endl;
+	}
+
 	if (mType->info.thinkEvent != -1) {
 		// onThink(self, interval)
 		if (!tfs::lua::reserveScriptEnv()) {


### PR DESCRIPTION
## Summary
- add new `/aidebug` talk action
- implement Game API for enabling AI debug logging
- expose API to Lua
- print AI information from Monster::onThink when debug is enabled
- document debugging controls

## Testing
- `cmake -B build -S .` *(fails: could not find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_684ef06e140c833297357f77da29c6d5